### PR TITLE
Ceda fbi core

### DIFF
--- a/nla_control/scripts/fix_problems.py
+++ b/nla_control/scripts/fix_problems.py
@@ -11,7 +11,6 @@ from django.db.models import Count
 from nla_control.models import *
 from nla_control.settings import *
 from nla_control.scripts.tidy_requests import in_other_request
-import nla_control
 import os
 import re
 import datetime

--- a/nla_control/scripts/process_requests.py
+++ b/nla_control/scripts/process_requests.py
@@ -18,22 +18,14 @@
 # import nla objects
 from nla_control.models import *
 from nla_control.settings import *
-import nla_control
 
 from django.core.mail import send_mail
 from django.db.models import Q
 
 import subprocess
-import datetime
-
-import time
-import re
-import socket
-from pytz import utc
-import sys, os
+import sys
 import random
 
-from ceda_elasticsearch_tools.index_tools import CedaFbi, CedaEo
 
 def update_requests():
     """Update all of the *TapeRequests* in the NLA system and mark *TapeRequests* as active or inactive.

--- a/nla_control/scripts/quick_tidy.py
+++ b/nla_control/scripts/quick_tidy.py
@@ -15,8 +15,6 @@ import datetime
 import sys
 from pytz import utc
 from nla_control.settings import *
-from nla_control.scripts.process_requests import update_requests
-from ceda_elasticsearch_tools.index_tools import CedaFbi, CedaEo
 import subprocess
 
 __author__ = 'sjp23'

--- a/nla_control/scripts/retrieve_files.py
+++ b/nla_control/scripts/retrieve_files.py
@@ -32,7 +32,7 @@ import socket
 from pytz import utc
 import sys, os
 
-from ceda_elasticsearch_tools.index_tools import CedaFbi, CedaEo
+from fbi_core import update_file_location
 
 
 def get_restore_disk(slot):
@@ -319,15 +319,7 @@ def wait_sd_get(p, slot, log_file_name, target_disk, retrieved_to_file_map):
         # modify the restored files in elastic search
         try:
             if len(restored_files) > 0:
-                fbi = CedaFbi(
-                        headers = {
-                            'x-api-key': CEDA_FBI_API_KEY
-                        }
-                      )
-                fbi.update_file_location(file_list=restored_files, on_disk=True)
-                #print "Updated Elastic Search index for files ",
-                #for f in restored_files:
-                #    print " - " + str(f)
+                update_file_location(path_list=restored_files, location="on_disk")
         except Exception as e:
             print("Failed updating Elastic Search Index ",)
             print(e, restored_files)

--- a/nla_control/scripts/retrieve_files.py
+++ b/nla_control/scripts/retrieve_files.py
@@ -315,7 +315,7 @@ def wait_sd_get(p, slot, log_file_name, target_disk, retrieved_to_file_map):
                 # update the restore_disk
                 target_disk.update()
                 # add the filename to the restored filenames
-                restored_files.append(f.logical_path.encode("utf-8"))
+                restored_files.append(f.logical_path)
         # modify the restored files in elastic search
         try:
             if len(restored_files) > 0:

--- a/nla_control/scripts/tidy_requests.py
+++ b/nla_control/scripts/tidy_requests.py
@@ -158,7 +158,7 @@ def tidy_requests():
                     print("Could not remove from archive: ", f.logical_path)
 
             # add to list of files to be altered in Elastic Search
-            removed_files.append(f.logical_path.encode("utf-8"))
+            removed_files.append(f.logical_path)
 
         print("Setting status of files in Elastic Search to not on disk")
         try:

--- a/nla_control/scripts/tidy_requests.py
+++ b/nla_control/scripts/tidy_requests.py
@@ -16,7 +16,7 @@ import sys
 from pytz import utc
 from nla_control.settings import *
 from nla_control.scripts.process_requests import update_requests
-from ceda_elasticsearch_tools.index_tools import CedaFbi, CedaEo
+from fbi_core import update_file_location
 import subprocess
 
 __author__ = 'sjp23'
@@ -164,15 +164,7 @@ def tidy_requests():
         try:
             # Open connection to index and update files
             if len(removed_files) > 0:
-                fbi = CedaFbi(
-                          headers = {
-                              'x-api-key' : CEDA_FBI_API_KEY
-                        }
-                      )
-                fbi.update_file_location(file_list=removed_files, on_disk=False)
-            print("Updated Elastic Search index for files ",)
-            for f in removed_files:
-                print(" - " + str(f))
+                update_file_location(path_list=removed_files, location="on_tape")
         except Exception as e:
             print("Failed updating Elastic Search Index ",)
             print(e, removed_files)

--- a/nla_control/tests.py
+++ b/nla_control/tests.py
@@ -4,7 +4,7 @@ import os
 
 # Create your tests here.
 
-from models import Quota, TapeRequest, TapeFile
+from models import Quota
 
 
 class SimpleTest(TestCase):

--- a/nla_control/urls.py
+++ b/nla_control/urls.py
@@ -1,5 +1,5 @@
 
-from django.conf.urls import url, include
+from django.conf.urls import url
 from nla_control.views import *
 
 urlpatterns = (

--- a/nla_control/views.py
+++ b/nla_control/views.py
@@ -1,7 +1,7 @@
 # Create your views here.
 from django.http import HttpResponse
 from nla_control.models import *
-from django.shortcuts import redirect, render_to_response, get_object_or_404
+from django.shortcuts import get_object_or_404
 import json
 import datetime
 from django.views.generic import View

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pyparsing==2.4.7
 pytz==2020.1
 requests==2.24.0
 tqdm==4.49.0
-ceda-elasticsearch-client==0.0.1
+ceda-elasticsearch-client
 -e git+https://github.com/cedadev/fbi-core.git#egg=fbi_core

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,10 @@ Django==2.2.13
 django-sizefield==1.0.0
 django-extensions==3.0.5
 django-multiselectfield==0.1.12
-psycopg2-binary==2.8.5
+#psycopg2-binary==2.8.5
 pyparsing==2.4.7
 pytz==2020.1
 requests==2.24.0
 tqdm==4.49.0
--e git+https://github.com/cedadev/ceda-elasticsearch-tools.git#egg=ceda_elasticsearch_tools
+ceda-elasticsearch-client==0.0.1
+-e git+https://github.com/cedadev/fbi-core.git#egg=fbi_core


### PR DESCRIPTION
Added back in support for updating the FBI by changing the library to FBI-core.
Requires FBI credentials in ~/.fbi.yml